### PR TITLE
heyawacky as heyawake without rectangular room requirement

### DIFF
--- a/src/pzpr/variety.js
+++ b/src/pzpr/variety.js
@@ -99,6 +99,7 @@ delete variety.extend;
 	hashikake :[0,1,"橋をかけろ","Hashiwokakero (Bridges)",'',{pzprurl:'hashi',kanpen:'hashi',alias:'bridges'}],
 	hebi      :[1,0,"へびいちご","Hebi-Ichigo",'',{old:'snakes'}],
 	herugolf  :[0,0,"ヘルゴルフ","Herugolf"],
+	heyawacky :[0,0,"へやわけ","Heyawacky",'heyawake'],
 	heyawake  :[0,1,"へやわけ","Heyawake",'heyawake'],
 	heyabon   :[1,1,"へやぼん","Heya-Bon",'bonsan',{kanpen:'satogaeri'}],
 	hitori    :[0,1,"ひとりにしてくれ","Hitori"],

--- a/src/variety/heyawake.js
+++ b/src/variety/heyawake.js
@@ -5,7 +5,7 @@
 	if(typeof module==='object' && module.exports){module.exports = [pidlist, classbase];}
 	else{ pzpr.classmgr.makeCustom(pidlist, classbase);}
 }(
-['heyawake','ayeheya'], {
+['heyawake','heyawacky','ayeheya'], {
 //---------------------------------------------------------
 // マウス入力系
 MouseEvent:{
@@ -235,7 +235,7 @@ AnsCheck:{
 		"checkFractal@ayeheya",
 		"checkShadeCellCount",
 		"checkCountinuousUnshadeCell",
-		"checkRoomRect"
+		"checkRoomRect@heyawake"
 	],
 
 	checkFractal : function(){


### PR DESCRIPTION
This partially addresses https://github.com/sabo2/pzprv3/issues/2 by adding a variant type of heyawake called heyawacky that doesn't check for rectangular rooms.